### PR TITLE
[BPF] Add native netkit BPF attachment support to Felix

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -970,25 +970,24 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
-  - name: "Felix: BPF program-loading check on 25.10 (nftables)"
+  - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
     run:
       when: "true"
     dependencies:
       - "Felix: Build"
     task:
       jobs:
-        - name: "Felix: BPF program-loading check on 25.10"
+        - name: "Felix: BPF tests on Ubuntu 25.10 with netkit"
           execution_time_limit:
-            minutes: 30
+            minutes: 60
           env_vars:
             - name: FELIX_TEST_GROUP
-              value: "bpf-25.10-nft-no-fv-with-ut"
-            - name: FELIX_FV_BPFATTACHTYPE
-              value: "tc"
+              value: "bpf-25.10-nft-with-ut"
+            - name: FELIX_FV_NETKIT
+              value: "Enabled"
           commands:
             - source felix/.semaphore/fv-prologue
-            # Only run the UT that checks that the precompiled BPF binaries are loadable.
-            - export UT_FOCUS="TestPrecompiledBinariesAreLoadable"
+            - export NUM_FV_BATCHES=60
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -970,25 +970,24 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
-  - name: "Felix: BPF program-loading check on 25.10 (nftables)"
+  - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
     run:
       when: "change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml','/.semaphore/semaphore.yml.d/02-global_job_config.yml','/.semaphore/semaphore.yml.d/03-promotions.yml','/.semaphore/semaphore.yml.d/09-blocks.yml','/.semaphore/semaphore.yml.d/99-after_pipeline.yml','/.semaphore/semaphore.yml.d/blocks/20-felix.yml','/.semaphore/vms/','/api/pkg/apis/projectcalico/v3/*.go','/api/pkg/defaults/*.go','/api/pkg/lib/numorstring/*.go','/app-policy/checker/*.go','/app-policy/policystore/*.go','/app-policy/types/*.go','/cni-plugin/pkg/dataplane/linux/*.go','/cni-plugin/pkg/types/*.go','/crypto/pkg/tls/*.go','/felix/**','/goldmane/pkg/client/*.go','/goldmane/pkg/goldmane/*.go','/goldmane/pkg/internal/flowcache/*.go','/goldmane/pkg/server/*.go','/goldmane/pkg/storage/*.go','/goldmane/pkg/stream/*.go','/goldmane/pkg/types/*.go','/goldmane/proto/*.go','/hack/test/certs/','/lib.Makefile','/lib/std/chanutil/*.go','/lib/std/time/*.go','/lib/std/uniquelabels/*.go','/lib/std/uniquestr/*.go','/libcalico-go/config/*.go','/libcalico-go/lib/apiconfig/*.go','/libcalico-go/lib/apis/crd.projectcalico.org/v1/scheme/*.go','/libcalico-go/lib/apis/internalapi/*.go','/libcalico-go/lib/apis/v1/*.go','/libcalico-go/lib/apis/v1/unversioned/*.go','/libcalico-go/lib/backend/*.go','/libcalico-go/lib/backend/api/*.go','/libcalico-go/lib/backend/encap/*.go','/libcalico-go/lib/backend/etcdv3/*.go','/libcalico-go/lib/backend/k8s/*.go','/libcalico-go/lib/backend/k8s/conversion/*.go','/libcalico-go/lib/backend/k8s/resources/*.go','/libcalico-go/lib/backend/model/*.go','/libcalico-go/lib/backend/syncersv1/bgpsyncer/*.go','/libcalico-go/lib/backend/syncersv1/dedupebuffer/*.go','/libcalico-go/lib/backend/syncersv1/felixsyncer/*.go','/libcalico-go/lib/backend/syncersv1/nodestatussyncer/*.go','/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/*.go','/libcalico-go/lib/backend/syncersv1/updateprocessors/*.go','/libcalico-go/lib/backend/watchersyncer/*.go','/libcalico-go/lib/clientv3/*.go','/libcalico-go/lib/consistenthash/*.go','/libcalico-go/lib/debugserver/*.go','/libcalico-go/lib/dispatcher/*.go','/libcalico-go/lib/epstatusfile/*.go','/libcalico-go/lib/errors/*.go','/libcalico-go/lib/hash/*.go','/libcalico-go/lib/health/*.go','/libcalico-go/lib/ipam/*.go','/libcalico-go/lib/json/*.go','/libcalico-go/lib/logutils/*.go','/libcalico-go/lib/metricsserver/*.go','/libcalico-go/lib/multireadbuf/*.go','/libcalico-go/lib/names/*.go','/libcalico-go/lib/namespace/*.go','/libcalico-go/lib/net/*.go','/libcalico-go/lib/netlinkutils/*.go','/libcalico-go/lib/options/*.go','/libcalico-go/lib/packedmap/*.go','/libcalico-go/lib/prometheus/*.go','/libcalico-go/lib/readlogger/*.go','/libcalico-go/lib/resources/*.go','/libcalico-go/lib/scope/*.go','/libcalico-go/lib/selector/*.go','/libcalico-go/lib/selector/parser/*.go','/libcalico-go/lib/selector/tokenizer/*.go','/libcalico-go/lib/set/*.go','/libcalico-go/lib/testutils/stacktrace/*.go','/libcalico-go/lib/validator/v1/*.go','/libcalico-go/lib/validator/v3/*.go','/libcalico-go/lib/watch/*.go','/libcalico-go/lib/winutils/*.go','/libcalico-go/lib/writelogger/*.go','/metadata.mk','/node/pkg/lifecycle/utils/*.go','/pkg/buildinfo/*.go','/pod2daemon/binder/*.go','/typha/cmd/calico-typha/*.go','/typha/cmd/typha-client/*.go','/typha/pkg/calc/*.go','/typha/pkg/config/*.go','/typha/pkg/daemon/*.go','/typha/pkg/discovery/*.go','/typha/pkg/jitter/*.go','/typha/pkg/k8s/*.go','/typha/pkg/logutils/*.go','/typha/pkg/promutils/*.go','/typha/pkg/snapcache/*.go','/typha/pkg/syncclient/*.go','/typha/pkg/syncproto/*.go','/typha/pkg/syncserver/*.go','/typha/pkg/tlsutils/*.go','typha/**/*Dockerfile*','typha/Makefile','typha/deps.txt'], {pipeline_file: 'ignore', exclude: ['/**/*.md','/**/.gitignore','/**/AUTHORS*','/**/CONTRIBUTING*','/**/DEVELOPER_GUIDE*','/**/LICENSE*','/**/README*','/**/SECURITY.md','/api/**/*_test.go','/app-policy/**/*_test.go','/cni-plugin/**/*_test.go','/crypto/**/*_test.go','/goldmane/**/*_test.go','/lib/**/*_test.go','/libcalico-go/**/*_test.go','/node/**/*_test.go','/pkg/**/*_test.go','/pod2daemon/**/*_test.go','/typha/**/*_test.go']})"
     dependencies:
       - "Felix: Build"
     task:
       jobs:
-        - name: "Felix: BPF program-loading check on 25.10"
+        - name: "Felix: BPF tests on Ubuntu 25.10 with netkit"
           execution_time_limit:
-            minutes: 30
+            minutes: 60
           env_vars:
             - name: FELIX_TEST_GROUP
-              value: "bpf-25.10-nft-no-fv-with-ut"
-            - name: FELIX_FV_BPFATTACHTYPE
-              value: "tc"
+              value: "bpf-25.10-nft-with-ut"
+            - name: FELIX_FV_NETKIT
+              value: "Enabled"
           commands:
             - source felix/.semaphore/fv-prologue
-            # Only run the UT that checks that the precompiled BPF binaries are loadable.
-            - export UT_FOCUS="TestPrecompiledBinariesAreLoadable"
+            - export NUM_FV_BATCHES=60
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
       epilogue:
         always:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -258,25 +258,24 @@
       - name: google-service-account-for-gce
       - name: gemini-api-key
       - name: fv-tests-guru-github-token
-- name: "Felix: BPF program-loading check on 25.10 (nftables)"
+- name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
   run:
     when: "${CHANGE_IN(felix,typha,non-go:/.semaphore/vms/)}"
   dependencies:
     - "Felix: Build"
   task:
     jobs:
-      - name: "Felix: BPF program-loading check on 25.10"
+      - name: "Felix: BPF tests on Ubuntu 25.10 with netkit"
         execution_time_limit:
-          minutes: 30
+          minutes: 60
         env_vars:
           - name: FELIX_TEST_GROUP
-            value: "bpf-25.10-nft-no-fv-with-ut"
-          - name: FELIX_FV_BPFATTACHTYPE
-            value: "tc"
+            value: "bpf-25.10-nft-with-ut"
+          - name: FELIX_FV_NETKIT
+            value: "Enabled"
         commands:
           - source felix/.semaphore/fv-prologue
-          # Only run the UT that checks that the precompiled BPF binaries are loadable.
-          - export UT_FOCUS="TestPrecompiledBinariesAreLoadable"
+          - export NUM_FV_BATCHES=60
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
     epilogue:
       always:

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -378,6 +378,7 @@ fv-no-prereqs:
 	  ARCH=$(ARCH) \
 	  FELIX_FV_ENABLE_BPF="$(FELIX_FV_ENABLE_BPF)" \
 	  FELIX_FV_NFTABLES="$(FELIX_FV_NFTABLES)" \
+	  FELIX_FV_NETKIT="$(FELIX_FV_NETKIT)" \
 	  FV_RACE_DETECTOR_ENABLED=$(FV_RACE_DETECTOR_ENABLED) \
 	  FV_BINARY=$(FV_BINARY) \
 	  CALICO_API_GROUP=$(CALICO_API_GROUP) \
@@ -397,6 +398,9 @@ fv-bpf:
 
 fv-bpf-no-prereqs:
 	$(MAKE) fv-no-prereqs FELIX_FV_ENABLE_BPF=true
+
+fv-bpf-netkit:
+	$(MAKE) fv FELIX_FV_ENABLE_BPF=true FELIX_FV_NETKIT=Enabled
 
 fv-nft:
 	$(MAKE) fv FELIX_FV_NFTABLES=Enabled

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -29,6 +29,7 @@ struct name {                              \
 	__s8 dscp;                             \
 	__s8 istio_dscp;                       \
 	__u32 maglev_lut_size;                 \
+	__u32 host_ifindex;                    \
 }
 
 DECLARE_TC_GLOBAL_DATA(cali_tc_global_data, ipv6_addr_t);

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -205,14 +205,21 @@ struct cali_tc_ctx {
 				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "State map lookup failed: DROP");	\
 				bpf_exit(TC_ACT_SHOT);				\
 			}							\
-			void * counters = counters_get(skb->ifindex);		\
-			if (!counters) {					\
-				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "no counters for %d: DROP", skb->ifindex);		\
-				bpf_exit(TC_ACT_SHOT);				\
-			}							\
 			struct cali_tc_globals *gl = state_get_globals_tc();	\
 			if (!gl) {						\
 				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "no globals: DROP");		\
+				bpf_exit(TC_ACT_SHOT);				\
+			}							\
+			/* Use host_ifindex from globals for the counters lookup.  \
+			 * For netkit, skb->ifindex is the peer ifindex which      \
+			 * differs from the primary (host-side) ifindex that the   \
+			 * maps are keyed by. host_ifindex is always the primary.  \
+			 */							\
+			__u32 __ifindex = gl->data.host_ifindex ?		\
+				gl->data.host_ifindex : skb->ifindex;		\
+			void * counters = counters_get(__ifindex);		\
+			if (!counters) {					\
+				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "no counters for %d: DROP", __ifindex);	\
 				bpf_exit(TC_ACT_SHOT);				\
 			}							\
 			struct pkt_scratch *scratch = (void *)(gl->__scratch); 	\

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2357,6 +2357,12 @@ func LoadObject(file string, data libbpf.GlobalData, mapsToBePinned ...string) (
 }
 
 func LoadObjectWithOptions(file string, data libbpf.GlobalData, configurator ObjectConfigurator, mapsToBePinned ...string) (*libbpf.Obj, error) {
+	return LoadObjectWithPinOverrides(file, data, configurator, nil, mapsToBePinned...)
+}
+
+// LoadObjectWithPinOverrides loads a BPF object with optional map pin path overrides.
+// mapPinOverrides maps C map names (e.g. "cali_progs_ing2") to alternate pin paths.
+func LoadObjectWithPinOverrides(file string, data libbpf.GlobalData, configurator ObjectConfigurator, mapPinOverrides map[string]string, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	obj, err := libbpf.OpenObject(file)
 	if err != nil {
 		return nil, err
@@ -2368,7 +2374,7 @@ func LoadObjectWithOptions(file string, data libbpf.GlobalData, configurator Obj
 		}
 	}
 
-	return loadObject(obj, data, mapsToBePinned...)
+	return loadObject(obj, data, mapPinOverrides, mapsToBePinned...)
 }
 
 func LoadObjectWithLogBuffer(file string, data libbpf.GlobalData, logBuf []byte, mapsToBePinned ...string) (*libbpf.Obj, error) {
@@ -2377,10 +2383,10 @@ func LoadObjectWithLogBuffer(file string, data libbpf.GlobalData, logBuf []byte,
 		return nil, err
 	}
 
-	return loadObject(obj, data, mapsToBePinned...)
+	return loadObject(obj, data, nil, mapsToBePinned...)
 }
 
-func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
+func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapPinOverrides map[string]string, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	success := false
 	defer func() {
 		if !success {
@@ -2416,16 +2422,19 @@ func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapsToBePinned ...strin
 		}
 
 		log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())
-		pinDir := MapPinDir()
+		pinPath := path.Join(MapPinDir(), mapName)
+		if override, ok := mapPinOverrides[mapName]; ok {
+			pinPath = override
+		}
 		// If mapsToBePinned is not specified, pin all the maps.
 		if len(mapsToBePinned) == 0 {
-			if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
+			if err := m.SetPinPath(pinPath); err != nil {
 				return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
 			}
 		} else {
 			for _, name := range mapsToBePinned {
 				if mapName == name {
-					if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
+					if err := m.SetPinPath(pinPath); err != nil {
 						return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
 					}
 				}

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -24,6 +24,7 @@ const (
 	ObjectDir    = "/usr/lib/calico/bpf"
 	CtlbPinDir   = "ctlb"
 	TcxPinDir    = DefaultBPFfsPath + "/tcx"
+	NetkitPinDir = DefaultBPFfsPath + "/netkit"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,9 +22,9 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
-	CtlbPinDir   = "ctlb"
-	TcxPinDir    = DefaultBPFfsPath + "/tcx"
-	NetkitPinDir = DefaultBPFfsPath + "/netkit"
+	CtlbPinDir         = "ctlb"
+	TcxPinDir          = DefaultBPFfsPath + "/tcx"
+	NetkitPinDir       = DefaultBPFfsPath + "/netkit"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -57,17 +57,19 @@ type IPMaps struct {
 }
 
 type CommonMaps struct {
-	StateMap         maps.Map
-	IfStateMap       maps.Map
-	RuleCountersMap  maps.Map
-	CountersMap      maps.Map
-	ProgramsMaps     []maps.Map
-	JumpMaps         []maps.MapWithDeleteIfExists
-	XDPProgramsMap   maps.Map
-	XDPJumpMap       maps.MapWithDeleteIfExists
-	ProfilingMap     maps.Map
-	CTLBProgramsMaps []maps.Map
-	QoSMap           maps.MapWithUpdateWithFlags
+	StateMap             maps.Map
+	IfStateMap           maps.Map
+	RuleCountersMap      maps.Map
+	CountersMap          maps.Map
+	ProgramsMaps         []maps.Map
+	JumpMaps             []maps.MapWithDeleteIfExists
+	NetkitProgramsMaps   []maps.Map
+	NetkitJumpMaps       []maps.MapWithDeleteIfExists
+	XDPProgramsMap       maps.Map
+	XDPJumpMap           maps.MapWithDeleteIfExists
+	ProfilingMap         maps.Map
+	CTLBProgramsMaps     []maps.Map
+	QoSMap               maps.MapWithUpdateWithFlags
 }
 
 type Maps struct {
@@ -105,6 +107,11 @@ func getCommonMaps() *CommonMaps {
 	jumpMaps := jump.Maps()
 	for _, jm := range jumpMaps {
 		commonMaps.JumpMaps = append(commonMaps.JumpMaps, jm.(maps.MapWithDeleteIfExists))
+	}
+	commonMaps.NetkitProgramsMaps = hook.NewNetkitProgramsMaps()
+	netkitJumpMaps := jump.NetkitMaps()
+	for _, jm := range netkitJumpMaps {
+		commonMaps.NetkitJumpMaps = append(commonMaps.NetkitJumpMaps, jm.(maps.MapWithDeleteIfExists))
 	}
 	return commonMaps
 }
@@ -202,8 +209,12 @@ func (c *CommonMaps) slice() []maps.Map {
 		c.QoSMap,
 	}
 	mapslice = append(mapslice, c.ProgramsMaps...)
+	mapslice = append(mapslice, c.NetkitProgramsMaps...)
 	mapslice = append(mapslice, c.CTLBProgramsMaps...)
 	for _, m := range c.JumpMaps {
+		mapslice = append(mapslice, m)
+	}
+	for _, m := range c.NetkitJumpMaps {
 		mapslice = append(mapslice, m)
 	}
 	return mapslice

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -68,12 +68,13 @@ const (
 var All = []Hook{Ingress, Egress, XDP}
 
 type AttachType struct {
-	Hook       Hook
-	Family     int
-	Type       tcdefs.EndpointType
-	LogLevel   string
-	ToHostDrop bool
-	DSR        bool
+	Hook           Hook
+	Family         int
+	Type           tcdefs.EndpointType
+	LogLevel       string
+	ToHostDrop     bool
+	DSR            bool
+	ProgAttachType string // "TC", "TCX", or "Netkit" — used as cache key to separate programs with different expected_attach_type
 }
 
 func (at AttachType) ObjectFile() string {

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -136,6 +136,9 @@ func ObjectFile(at AttachType) string {
 	objectFilesLock.Lock()
 	defer objectFilesLock.Unlock()
 
+	// ProgAttachType is not part of the object file selection — the same
+	// BPF object is used for TC, TCX, and Netkit. Zero it out for lookup.
+	at.ProgAttachType = ""
 	return objectFiles[at]
 }
 

--- a/felix/bpf/hook/map.go
+++ b/felix/bpf/hook/map.go
@@ -334,7 +334,8 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 			mapName, m.KeySize(), m.ValueSize(), path.Join(bpfdefs.GlobalPinDir, mapName), file)
 	}
 
-	if progAttachType == "TCX" {
+	switch progAttachType {
+	case "TCX":
 		for prog, err := obj.FirstProgram(); prog != nil && err == nil; prog, err = prog.NextProgram() {
 			attachType := libbpf.AttachTypeTcxEgress
 			if pm.expectedAttachType == "ingress" {
@@ -342,6 +343,19 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 			}
 			if err := obj.SetAttachType(prog.Name(), attachType); err != nil {
 				return fmt.Errorf("error setting attach type for program %s: %w", prog.Name(), err)
+			}
+		}
+	case "Netkit":
+		for prog, err := obj.FirstProgram(); prog != nil && err == nil; prog, err = prog.NextProgram() {
+			// Map direction to netkit attach type:
+			// ingress ProgramsMap (traffic from pod) -> BPF_NETKIT_PEER
+			// egress ProgramsMap (traffic to pod) -> BPF_NETKIT_PRIMARY
+			attachType := libbpf.AttachTypeNetkitPrimary
+			if pm.expectedAttachType == "ingress" {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+			if err := obj.SetAttachType(prog.Name(), attachType); err != nil {
+				return fmt.Errorf("error setting netkit attach type for program %s: %w", prog.Name(), err)
 			}
 		}
 	}

--- a/felix/bpf/hook/map.go
+++ b/felix/bpf/hook/map.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
+	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	bpfmaps "github.com/projectcalico/calico/felix/bpf/maps"
 )
@@ -154,6 +155,12 @@ type ProgramsMap struct {
 
 	expectedAttachType string
 	nextIdx            atomic.Int64
+
+	// mapPinOverrides maps C object map names (e.g. "cali_progs_ing2") to
+	// alternate pin paths. Used by netkit ProgramsMaps to redirect prog_array
+	// maps to a netkit-specific directory, so that netkit programs (which have
+	// a different expected_attach_type) get their own prog_array instances.
+	mapPinOverrides map[string]string
 }
 
 type program struct {
@@ -184,6 +191,93 @@ func NewProgramsMaps() []bpfmaps.Map {
 		NewIngressProgramsMap(),
 		NewEgressProgramsMap(),
 	}
+}
+
+var NetkitIngressProgramsMapParameters = bpfmaps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: maxPrograms,
+	Name:       "cali_p_nk_ing",
+	Version:    2,
+}
+
+var NetkitEgressProgramsMapParameters = bpfmaps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: maxPrograms,
+	Name:       "cali_p_nk_egr",
+	Version:    2,
+}
+
+func NewNetkitProgramsMaps() []bpfmaps.Map {
+	return []bpfmaps.Map{
+		NewNetkitIngressProgramsMap(),
+		NewNetkitEgressProgramsMap(),
+	}
+}
+
+func NewNetkitIngressProgramsMap() bpfmaps.Map {
+	pm := newProgramsMap(NetkitIngressProgramsMapParameters, "ingress")
+	pmTyped := pm.(*ProgramsMap)
+	pmTyped.mapPinOverrides = netkitPinOverrides(
+		IngressProgramsMapParameters, NetkitIngressProgramsMapParameters,
+		jump.IngressMapParameters, jump.NetkitIngressMapParameters,
+	)
+	return pm
+}
+
+func NewNetkitEgressProgramsMap() bpfmaps.Map {
+	pm := newProgramsMap(NetkitEgressProgramsMapParameters, "egress")
+	pmTyped := pm.(*ProgramsMap)
+	pmTyped.mapPinOverrides = netkitPinOverrides(
+		EgressProgramsMapParameters, NetkitEgressProgramsMapParameters,
+		jump.EgressMapParameters, jump.NetkitEgressMapParameters,
+	)
+	return pm
+}
+
+// netkitPinOverrides builds a map from the C object's prog_array map names
+// to netkit-specific pin paths. The kernel requires all programs in a prog_array
+// to have the same expected_attach_type; netkit programs (BPF_NETKIT_PEER/PRIMARY)
+// are incompatible with TC/TCX programs, so they need separate prog_array instances.
+// TC and TCX can share prog_arrays because the kernel treats their attach types as
+// compatible within BPF_PROG_TYPE_SCHED_CLS.
+func netkitPinOverrides(
+	tcProgs, nkProgs bpfmaps.MapParameters,
+	tcJump, nkJump bpfmaps.MapParameters,
+) map[string]string {
+	return map[string]string{
+		tcProgs.VersionedName(): nkProgs.VersionedFilename(),
+		tcJump.VersionedName():  nkJump.VersionedFilename(),
+	}
+}
+
+// NetkitPinOverridesIngress returns pin path overrides for ingress prog_array maps.
+func NetkitPinOverridesIngress() map[string]string {
+	return netkitPinOverrides(
+		IngressProgramsMapParameters, NetkitIngressProgramsMapParameters,
+		jump.IngressMapParameters, jump.NetkitIngressMapParameters,
+	)
+}
+
+// NetkitPinOverridesEgress returns pin path overrides for egress prog_array maps.
+func NetkitPinOverridesEgress() map[string]string {
+	return netkitPinOverrides(
+		EgressProgramsMapParameters, NetkitEgressProgramsMapParameters,
+		jump.EgressMapParameters, jump.NetkitEgressMapParameters,
+	)
+}
+
+// NetkitPinOverridesBoth returns pin path overrides for both ingress and egress
+// prog_array maps. Used when the attach point is copied for both directions.
+func NetkitPinOverridesBoth() map[string]string {
+	m := NetkitPinOverridesIngress()
+	for k, v := range NetkitPinOverridesEgress() {
+		m[k] = v
+	}
+	return m
 }
 
 func NewIngressProgramsMap() bpfmaps.Map {
@@ -327,11 +421,15 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 		if err := pm.setMapSize(m); err != nil {
 			return fmt.Errorf("error setting map size %s : %w", mapName, err)
 		}
-		if err := m.SetPinPath(path.Join(bpfdefs.GlobalPinDir, mapName)); err != nil {
+		pinPath := path.Join(bpfdefs.GlobalPinDir, mapName)
+		if override, ok := pm.mapPinOverrides[mapName]; ok {
+			pinPath = override
+		}
+		if err := m.SetPinPath(pinPath); err != nil {
 			return fmt.Errorf("error pinning map %s: %w", mapName, err)
 		}
 		log.Debugf("map %s k %d v %d pinned to %s for generic object file %s",
-			mapName, m.KeySize(), m.ValueSize(), path.Join(bpfdefs.GlobalPinDir, mapName), file)
+			mapName, m.KeySize(), m.ValueSize(), pinPath, file)
 	}
 
 	switch progAttachType {

--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -74,6 +74,35 @@ func XDPMap() maps.Map {
 	return maps.NewPinnedMap(XDPMapParameters)
 }
 
+// Netkit maps are identical to TC maps but pinned to a separate directory
+// so that netkit-attached programs (which have a different expected_attach_type)
+// get their own prog_array instances. The kernel requires all programs in a
+// prog_array to share the same expected_attach_type.
+var NetkitIngressMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: TCMaxEntries,
+	Name:       "cali_j_nk_ing",
+	Version:    2,
+}
+
+var NetkitEgressMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: TCMaxEntries,
+	Name:       "cali_j_nk_egr",
+	Version:    2,
+}
+
+func NetkitMaps() []maps.Map {
+	return []maps.Map{
+		maps.NewPinnedMap(NetkitIngressMapParameters),
+		maps.NewPinnedMap(NetkitEgressMapParameters),
+	}
+}
+
 func Key(idx int) []byte {
 	var k [4]byte
 	binary.LittleEndian.PutUint32(k[:], uint32(idx))

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -347,6 +347,22 @@ func (o *Obj) AttachTCX(secName, ifName string) (*Link, error) {
 	return &Link{link: link}, nil
 }
 
+func (o *Obj) AttachNetkit(secName, ifName string) (*Link, error) {
+	cSecName := C.CString(secName)
+	cIfName := C.CString(ifName)
+	defer C.free(unsafe.Pointer(cSecName))
+	defer C.free(unsafe.Pointer(cIfName))
+	ifIndex, err := C.if_nametoindex(cIfName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting ifindex for %s: %w", ifName, err)
+	}
+	link, err := C.bpf_netkit_program_attach(o.obj, cSecName, C.int(ifIndex))
+	if err != nil {
+		return nil, fmt.Errorf("error attaching netkit program: %w", err)
+	}
+	return &Link{link: link}, nil
+}
+
 func (o *Obj) AttachXDP(ifName, progName string, oldID int, mode uint) (int, error) {
 	cProgName := C.CString(progName)
 	cIfName := C.CString(ifName)
@@ -610,6 +626,9 @@ const (
 	AttachTypeTcxIngress uint32 = C.BPF_TCX_INGRESS
 	AttachTypeTcxEgress  uint32 = C.BPF_TCX_EGRESS
 	AttachTypeXDP        uint32 = C.BPF_XDP
+
+	AttachTypeNetkitPrimary uint32 = C.BPF_NETKIT_PRIMARY
+	AttachTypeNetkitPeer    uint32 = C.BPF_NETKIT_PEER
 )
 
 func (t *TcGlobalData) Set(m *Map) error {

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -673,6 +673,7 @@ func (t *TcGlobalData) Set(m *Map) error {
 		C.short(t.DSCP),
 		C.short(t.IstioDSCP),
 		C.uint(t.MaglevLUTSize),
+		C.uint(t.HostIfindex),
 	)
 
 	return err

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -170,7 +170,7 @@ void bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, b
 
 struct bpf_link* bpf_tcx_program_attach(struct bpf_object *obj, char *secName, int ifIndex)
 {
-	DECLARE_LIBBPF_OPTS(bpf_tcx_opts, attach); 
+	DECLARE_LIBBPF_OPTS(bpf_tcx_opts, attach);
 	struct bpf_program *prog = bpf_object__find_program_by_name(obj, secName);
 	if (!prog) {
 		errno = ENOENT;
@@ -183,6 +183,23 @@ struct bpf_link* bpf_tcx_program_attach(struct bpf_object *obj, char *secName, i
         }
         set_errno(err);
         return link;
+}
+
+struct bpf_link* bpf_netkit_program_attach(struct bpf_object *obj, char *secName, int ifIndex)
+{
+	DECLARE_LIBBPF_OPTS(bpf_netkit_opts, attach);
+	struct bpf_program *prog = bpf_object__find_program_by_name(obj, secName);
+	if (!prog) {
+		errno = ENOENT;
+		return NULL;
+	}
+	struct bpf_link *link = bpf_program__attach_netkit(prog, ifIndex, &attach);
+	int err = libbpf_get_error(link);
+	if (err) {
+		link = NULL;
+	}
+	set_errno(err);
+	return link;
 }
 
 void bpf_tc_program_detach(int ifindex, int handle, int pref, bool ingress)

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -297,7 +297,8 @@ void bpf_tc_set_globals(struct bpf_map *map,
 			uint *jumps6,
 			short dscp,
 			short istio_dscp,
-			uint maglev_lut_size)
+			uint maglev_lut_size,
+			uint host_ifindex)
 {
 	struct cali_tc_global_data v4 = {
 		.tunnel_mtu = tmtu,
@@ -315,6 +316,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 		.dscp = dscp,
 		.istio_dscp = istio_dscp,
 		.maglev_lut_size = maglev_lut_size,
+		.host_ifindex = host_ifindex,
 	};
 
 	strncpy(v4.iface_name, iface_name, sizeof(v4.iface_name));

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -50,6 +50,7 @@ type TcGlobalData struct {
 	DSCP          int8
 	IstioDSCP     int8
 	MaglevLUTSize uint32
+	HostIfindex   uint32
 }
 
 type XDPGlobalData struct {

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -83,6 +83,11 @@ type AttachPoint struct {
 	ProgramsMap                   maps.Map
 }
 
+// AttachOptionNetkit is used internally to signal netkit attachment.
+// It is not part of the public API (not user-configurable); Felix auto-selects
+// it when it detects a netkit device.
+const AttachOptionNetkit = "Netkit"
+
 var ErrDeviceNotFound = errors.New("device not found")
 var ErrInterrupted = errors.New("dump interrupted")
 
@@ -155,6 +160,19 @@ func (ap *AttachPoint) AttachProgram() error {
 	// configuration further to the selected set of programs.
 
 	binaryToLoad := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("tc_preamble_%s.o", ap.Hook))
+	if ap.AttachType == AttachOptionNetkit {
+		err := ap.attachNetkitProgram(binaryToLoad)
+		if err != nil {
+			return fmt.Errorf("error attaching netkit program %s:%s: %w", ap.Iface, ap.Hook, err)
+		}
+		// Clean up legacy TC and TCX attachments from previous runs.
+		_ = RemoveQdisc(ap.Iface)
+		if _, err := os.Stat(ap.ProgPinPath()); err == nil {
+			_ = ap.detachTcxProgram()
+		}
+		logCxt.Info("Program attached to netkit.")
+		return nil
+	}
 	if ap.AttachType == apiv3.BPFAttachOptionTCX {
 		err := ap.attachTCXProgram(binaryToLoad)
 		if err != nil {
@@ -205,6 +223,72 @@ func (ap *AttachPoint) ProgPinPath() string {
 	return path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_%s", strings.ReplaceAll(ap.Iface, ".", ""), ap.Hook))
 }
 
+func (ap *AttachPoint) NetkitProgPinPath() string {
+	return path.Join(bpfdefs.NetkitPinDir, fmt.Sprintf("%s_%s", strings.ReplaceAll(ap.Iface, ".", ""), ap.Hook))
+}
+
+func (ap *AttachPoint) attachNetkitProgram(binaryToLoad string) error {
+	logCxt := log.WithField("attachPoint", ap)
+	obj, err := ap.loadObject(binaryToLoad, func(obj *libbpf.Obj) error {
+		// Map TC hook direction to netkit attach type:
+		// hook.Ingress (traffic from pod) -> BPF_NETKIT_PEER (peer transmits)
+		// hook.Egress (traffic to pod) -> BPF_NETKIT_PRIMARY (primary transmits)
+		attachType := libbpf.AttachTypeNetkitPrimary
+		if ap.Hook == hook.Ingress {
+			attachType = libbpf.AttachTypeNetkitPeer
+		}
+		return obj.SetAttachType("cali_tc_preamble", attachType)
+	})
+	if err != nil {
+		logCxt.Warn("Failed to load program for netkit")
+		return fmt.Errorf("object %w", err)
+	}
+	defer obj.Close()
+	progPinPath := ap.NetkitProgPinPath()
+	if _, err := os.Stat(progPinPath); err == nil {
+		link, err := libbpf.OpenLink(progPinPath)
+		if err != nil {
+			return fmt.Errorf("error opening link %s: %w", progPinPath, err)
+		}
+		defer link.Close()
+		if err := link.Update(obj, "cali_tc_preamble"); err != nil {
+			if errors.Is(err, unix.ENOLINK) {
+				logCxt.Debug("Netkit link severed from interface, re-attaching")
+				os.Remove(progPinPath)
+				goto attachNew
+			}
+			return fmt.Errorf("error updating program %s: %w", progPinPath, err)
+		}
+		return nil
+	}
+attachNew:
+	link, err := obj.AttachNetkit("cali_tc_preamble", ap.Iface)
+	if err != nil {
+		return err
+	}
+	defer link.Close()
+	err = link.Pin(progPinPath)
+	if err != nil {
+		return fmt.Errorf("error pinning netkit link: %w", err)
+	}
+	return nil
+}
+
+func (ap *AttachPoint) detachNetkitProgram() error {
+	progPinPath := ap.NetkitProgPinPath()
+	defer os.Remove(progPinPath)
+	link, err := libbpf.OpenLink(progPinPath)
+	if err != nil {
+		return fmt.Errorf("error opening netkit link %s: %w", progPinPath, err)
+	}
+	defer link.Close()
+	err = link.Detach()
+	if err != nil {
+		return fmt.Errorf("error detaching netkit link %s: %w", progPinPath, err)
+	}
+	return nil
+}
+
 func (ap *AttachPoint) detachTcxProgram() error {
 	progPinPath := ap.ProgPinPath()
 	defer os.Remove(progPinPath)
@@ -229,7 +313,11 @@ func (ap *AttachPoint) detachTcProgram() error {
 }
 
 func (ap *AttachPoint) DetachProgram() error {
-	err := ap.detachTcxProgram()
+	err := ap.detachNetkitProgram()
+	if err != nil {
+		log.Warnf("error detaching netkit program from %s hook %s : %s", ap.Iface, ap.Hook, err)
+	}
+	err = ap.detachTcxProgram()
 	if err != nil {
 		log.Warnf("error detaching tcx program from %s hook %s : %s", ap.Iface, ap.Hook, err)
 	}
@@ -571,4 +659,46 @@ var IsTcxSupported = sync.OnceValue(func() bool {
 	defer obj.Close()
 	_, err = obj.AttachTCX("cali_tcx_test", name)
 	return err == nil
+})
+
+var IsNetkitSupported = sync.OnceValue(func() bool {
+	name := "testNk"
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Flags = net.FlagUp
+	nk := &netlink.Netkit{
+		LinkAttrs: la,
+		Mode:      netlink.NETKIT_MODE_L2,
+	}
+	err := netlink.LinkAdd(nk)
+	if err != nil {
+		log.WithError(err).Debug("Netkit not supported on this kernel")
+		return false
+	}
+
+	defer func() {
+		if err := netlink.LinkDel(nk); err != nil {
+			log.Warnf("failed to delete netkit interface %s: %s", name, err)
+		}
+	}()
+
+	// Use LoadObjectWithOptions with a configurator to set the netkit attach
+	// type before loading. bpf.LoadObject calls Load() internally, so we
+	// must set the attach type in the configurator callback.
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, "tcx_test.o")
+	obj, err := bpf.LoadObjectWithOptions(binaryToLoad, &libbpf.TcGlobalData{}, func(obj *libbpf.Obj) error {
+		return obj.SetAttachType("cali_tcx_test", libbpf.AttachTypeNetkitPrimary)
+	})
+	if err != nil {
+		log.WithError(err).Debug("Failed to load test object for netkit probe")
+		return false
+	}
+	defer obj.Close()
+	link, err := obj.AttachNetkit("cali_tcx_test", name)
+	if err != nil {
+		log.WithError(err).Debug("Netkit BPF attachment not supported")
+		return false
+	}
+	link.Close()
+	return true
 })

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -81,6 +81,7 @@ type AttachPoint struct {
 	IstioDSCP                     int8
 	MaglevLUTSize                 uint32
 	ProgramsMap                   maps.Map
+	MapPinOverrides               map[string]string // prog_array pin path overrides for netkit
 }
 
 // AttachOptionNetkit is used internally to signal netkit attachment.
@@ -100,7 +101,7 @@ func (ap *AttachPoint) Log() *log.Entry {
 }
 
 func (ap *AttachPoint) loadObject(file string, configurator bpf.ObjectConfigurator) (*libbpf.Obj, error) {
-	obj, err := bpf.LoadObjectWithOptions(file, ap.Configure(), configurator)
+	obj, err := bpf.LoadObjectWithPinOverrides(file, ap.Configure(), configurator, ap.MapPinOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s: %w", file, err)
 	}

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -526,6 +526,7 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 		DSCP:          ap.DSCP,
 		IstioDSCP:     ap.IstioDSCP,
 		MaglevLUTSize: ap.MaglevLUTSize,
+		HostIfindex:   uint32(ap.IfIndex),
 	}
 
 	if ap.Profiling == "Enabled" {

--- a/felix/bpf/tc/cleanup.go
+++ b/felix/bpf/tc/cleanup.go
@@ -127,7 +127,8 @@ func CleanUpProgramsAndPins() {
 			}
 		}
 	}
-	// Remove all tcx pins
+	// Remove all tcx and netkit pins
 	os.RemoveAll(bpfdefs.TcxPinDir)
+	os.RemoveAll(bpfdefs.NetkitPinDir)
 	bpf.CleanUpCalicoPins(bpfdefs.DefaultBPFfsPath)
 }

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -1404,6 +1404,84 @@ func TestAttachTcx(t *testing.T) {
 	Expect(len(tcxProgs)).To(Equal(1))
 }
 
+func TestAttachNetkit(t *testing.T) {
+	RegisterTestingT(t)
+
+	if !tc.IsNetkitSupported() {
+		t.Skip("Netkit not supported on this kernel")
+	}
+
+	bpfmaps, err := bpfmap.CreateBPFMaps(false)
+	Expect(err).NotTo(HaveOccurred())
+
+	loglevel := "off"
+	bpfConfig := &linux.Config{
+		Hostname:              "uthost",
+		BPFLogLevel:           loglevel,
+		BPFDataIfacePattern:   regexp.MustCompile("^hostep[12]"),
+		VXLANMTU:              1000,
+		VXLANPort:             1234,
+		BPFNodePortDSREnabled: false,
+		RulesConfig: rules.Config{
+			EndpointToHostAction: "RETURN",
+		},
+		BPFExtToServiceConnmark: 0,
+		BPFPolicyDebugEnabled:   true,
+		BPFAttachType:           v3.BPFAttachOptionTCX, // Global default is TCX; netkit is auto-detected per device.
+	}
+
+	bpfEpMgr, err := newBPFTestEpMgr(
+		bpfConfig,
+		bpfmaps,
+		regexp.MustCompile("^workloadep[0123]"),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create a netkit device instead of a veth. Felix should auto-detect it
+	// and use native netkit BPF attachment.
+	workload0 := createNetkitName("workloadep0")
+	defer deleteLink(workload0)
+
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
+	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
+	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+		Id: &proto.WorkloadEndpointID{
+			OrchestratorId: "k8s",
+			WorkloadId:     "workloadep0",
+			EndpointId:     "workloadep0",
+		},
+		Endpoint: &proto.WorkloadEndpoint{Name: "workloadep0"},
+	})
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+
+	// Netkit should not create a qdisc.
+	hasQdisc, err := tc.HasQdisc("workloadep0")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(hasQdisc).To(BeFalse())
+
+	// No TC programs should be attached.
+	progs, err := tc.ListAttachedPrograms("workloadep0", hook.Ingress.String(), true)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(progs)).To(Equal(0))
+
+	// No TCX programs should be attached.
+	tcxProgs, err := tc.ListAttachedTcxPrograms("workloadep0", "ingress")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(tcxProgs)).To(Equal(0))
+
+	// No TCX pins should exist.
+	_, err = os.Stat(bpfdefs.TcxPinDir + "/workloadep0_ingress")
+	Expect(err).To(HaveOccurred())
+
+	// Netkit pins should exist for both ingress and egress.
+	_, err = os.Stat(bpfdefs.NetkitPinDir + "/workloadep0_ingress")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = os.Stat(bpfdefs.NetkitPinDir + "/workloadep0_egress")
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func TestLogFilters(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -111,6 +111,19 @@ func createVethName(name string) netlink.Link {
 	return veth
 }
 
+func createNetkitName(name string) netlink.Link {
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Flags = net.FlagUp
+	var nk netlink.Link = &netlink.Netkit{
+		LinkAttrs: la,
+		Mode:      netlink.NETKIT_MODE_L2,
+	}
+	err := netlink.LinkAdd(nk)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create test netkit: %q", name))
+	return nk
+}
+
 func createHostIf(name string) netlink.Link {
 	la := netlink.NewLinkAttrs()
 	la.Name = name

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1123,6 +1123,18 @@ func cleanupTcxPins(iface string) {
 	}
 }
 
+func cleanupNetkitPins(iface string) {
+	for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
+		ap := tc.AttachPoint{
+			AttachPoint: bpf.AttachPoint{
+				Iface: iface,
+				Hook:  attachHook,
+			},
+		}
+		os.Remove(ap.NetkitProgPinPath())
+	}
+}
+
 func (m *bpfEndpointManager) cleanupOldTcAttach(iface string) error {
 	ap := tc.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
@@ -1188,12 +1200,13 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 		return
 	}
 
-	if update.State == ifacemonitor.StateNotPresent && m.bpfAttachType == apiv3.BPFAttachOptionTCX {
-		// Delete the tcx pins if the interface is gone.
+	if update.State == ifacemonitor.StateNotPresent {
+		// Delete tcx/netkit pins if the interface is gone.
 		// Check if the interface still exists, as we might get events out of order.
 		_, err := m.dp.getIfaceLink(update.Name)
 		if err != nil {
 			cleanupTcxPins(update.Name)
+			cleanupNetkitPins(update.Name)
 		}
 	}
 	// Should be safe without the lock since there shouldn't be any active background threads
@@ -1227,6 +1240,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			allIfaces.Discard(update.Name)
 			m.hostIfaceTrees.deleteIface(update.Name)
 			m.dirtyIfaceNames.AddSet(allIfaces)
+		}
+	} else if update.State != ifacemonitor.StateNotPresent {
+		// For workload interfaces, detect netkit devices so Felix can use
+		// native BPF attachment instead of TC/TCX.
+		if link, err := m.dp.getIfaceLink(update.Name); err == nil {
+			curIfaceType = m.getIfaceTypeFromLink(link)
 		}
 	}
 
@@ -2394,10 +2413,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	ap := m.calculateTCAttachPoint(ifaceName)
 	ap.IfIndex = ifindex
 
-	// For netkit devices, override the attachment mechanism to use native netkit BPF
-	// attachment instead of TC/TCX. This is per-device: veth and netkit endpoints can
-	// coexist on the same node.
-	if ifaceType == IfaceTypeNetkit && tc.IsNetkitSupported() {
+	// For workload netkit devices, override the attachment mechanism to use native
+	// netkit BPF attachment instead of TC/TCX. Only workload interfaces are ours to
+	// manage this way — other netkit devices (host/data interfaces) are not ours.
+	if ifaceType == IfaceTypeNetkit && m.isWorkloadIface(ifaceName) && tc.IsNetkitSupported() {
 		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
 	}
 	if wep != nil && wep.QosControls != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2500,6 +2500,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		// so we set overrides for both ingress and egress here. The ProgramsMap
 		// is set per-direction in wepApplyPolicyToDirection.
 		ap.MapPinOverrides = hook.NetkitPinOverridesBoth()
+		// bpf_redirect_peer requires a TC ingress context (skb_at_tc_ingress),
+		// but netkit programs run in xmit context. Disable redirect_peer so the
+		// FIB path uses plain bpf_redirect instead.
+		ap.RedirectPeer = false
 	}
 	if wep != nil && wep.QosControls != nil {
 		// QoSControls are present, update state

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -140,6 +140,7 @@ const (
 	IfaceTypeL3
 	IfaceTypeBond
 	IfaceTypeBondSlave
+	IfaceTypeNetkit
 	IfaceTypeUnknown
 )
 
@@ -2313,6 +2314,7 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		endpointID   *types.WorkloadEndpointID
 		ifaceUp      bool
 		ifindex      int
+		ifaceType    IfaceType
 		hasIstioDSCP bool
 	)
 
@@ -2323,6 +2325,7 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		ifindex = iface.info.ifIndex
 		endpointID = iface.info.endpointID
 		state = iface.dpState
+		ifaceType = iface.info.ifaceType
 		hasIstioDSCP = iface.info.hasIstioDSCP
 		return false
 	})
@@ -2339,25 +2342,29 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	// datastore.  If we don't have an endpoint then we'll attach a program to block traffic and we'll
 	// get the jump map ready to insert the policy if the endpoint shows up.
 
-	// Attach the qdisc first; it is shared between the directions.
-	existed, err := m.dp.ensureQdisc(ifaceName)
-	if err != nil {
-		if isLinkNotFoundError(err) {
-			// Interface is gone, nothing to do.
-			logrus.WithField("ifaceName", ifaceName).Debug(
-				"Ignoring request to program interface that is not present.")
-			return state, nil
+	// Netkit devices don't need a qdisc — only legacy TC does.
+	if ifaceType != IfaceTypeNetkit {
+		// Attach the qdisc first; it is shared between the directions.
+		existed, err := m.dp.ensureQdisc(ifaceName)
+		if err != nil {
+			if isLinkNotFoundError(err) {
+				// Interface is gone, nothing to do.
+				logrus.WithField("ifaceName", ifaceName).Debug(
+					"Ignoring request to program interface that is not present.")
+				return state, nil
+			}
+			return state, err
 		}
-		return state, err
-	}
-	if !existed {
-		// Cannot be ready if the qdisc is not there so no program can be
-		// attached. Do the full attach!
-		state.v4Readiness = ifaceNotReady
-		state.v6Readiness = ifaceNotReady
+		if !existed {
+			// Cannot be ready if the qdisc is not there so no program can be
+			// attached. Do the full attach!
+			state.v4Readiness = ifaceNotReady
+			state.v6Readiness = ifaceNotReady
+		}
 	}
 
 	var (
+		err                   error
 		ingressErr, egressErr error
 		err4, err6            error
 		ingressAP4, egressAP4 *tc.AttachPoint
@@ -2386,6 +2393,13 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 
 	ap := m.calculateTCAttachPoint(ifaceName)
 	ap.IfIndex = ifindex
+
+	// For netkit devices, override the attachment mechanism to use native netkit BPF
+	// attachment instead of TC/TCX. This is per-device: veth and netkit endpoints can
+	// coexist on the same node.
+	if ifaceType == IfaceTypeNetkit && tc.IsNetkitSupported() {
+		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
+	}
 	if wep != nil && wep.QosControls != nil {
 		// QoSControls are present, update state
 
@@ -3780,8 +3794,9 @@ func (m *bpfEndpointManager) ensureQdisc(iface string) (bool, error) {
 	return tc.EnsureQdisc(iface)
 }
 
-func (m *bpfEndpointManager) loadTCObj(at hook.AttachType, pm *hook.ProgramsMap) (hook.Layout, error) {
-	layout, err := pm.LoadObj(at, string(m.bpfAttachType))
+func (m *bpfEndpointManager) loadTCObj(at hook.AttachType, pm *hook.ProgramsMap, progAttachType string) (hook.Layout, error) {
+	at.ProgAttachType = progAttachType
+	layout, err := pm.LoadObj(at, progAttachType)
 	if err != nil {
 		return nil, err
 	}
@@ -3791,7 +3806,7 @@ func (m *bpfEndpointManager) loadTCObj(at hook.AttachType, pm *hook.ProgramsMap)
 	}
 
 	at.LogLevel = "off"
-	layoutNoDebug, err := pm.LoadObj(at, string(m.bpfAttachType))
+	layoutNoDebug, err := pm.LoadObj(at, progAttachType)
 	if err != nil {
 		return nil, err
 	}
@@ -3804,24 +3819,29 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 	var err error
 
 	if aptc, ok := ap.(*tc.AttachPoint); ok {
+		// Derive the program attach type from the attach point. For netkit
+		// devices this will be "Netkit", otherwise it comes from the global config.
+		progAttachType := string(aptc.AttachType)
+
 		at := hook.AttachType{
-			Hook:       aptc.HookName(),
-			Type:       aptc.Type,
-			LogLevel:   aptc.LogLevel,
-			ToHostDrop: aptc.ToHostDrop,
-			DSR:        aptc.DSR,
+			Hook:           aptc.HookName(),
+			Family:         int(ipFamily),
+			Type:           aptc.Type,
+			LogLevel:       aptc.LogLevel,
+			ToHostDrop:     aptc.ToHostDrop,
+			DSR:            aptc.DSR,
+			ProgAttachType: progAttachType,
 		}
 
-		at.Family = int(ipFamily)
 		policyIdx := aptc.PolicyIdxV4
 		ap.Log().Debugf("ensureProgramLoaded %d", ipFamily)
 		if ipFamily == proto.IPVersion_IPV6 {
-			if aptc.HookLayoutV6, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap)); err != nil {
+			if aptc.HookLayoutV6, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap), progAttachType); err != nil {
 				return fmt.Errorf("loading generic v%d tc hook program: %w", ipFamily, err)
 			}
 			policyIdx = aptc.PolicyIdxV6
 		} else {
-			if aptc.HookLayoutV4, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap)); err != nil {
+			if aptc.HookLayoutV4, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap), progAttachType); err != nil {
 				return fmt.Errorf("loading generic v%d tc hook program: %w", ipFamily, err)
 			}
 		}
@@ -4603,6 +4623,8 @@ func (m *bpfEndpointManager) getIfaceTypeFromLink(link netlink.Link) IfaceType {
 	}
 
 	switch link.Type() {
+	case "netkit":
+		return IfaceTypeNetkit
 	case "ipip":
 		return IfaceTypeIPIP
 	case "wireguard":

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -320,9 +320,13 @@ type bpfEndpointManager struct {
 	legacyCleanUp           bool
 	hostIfaceTrees          bpfIfaceTrees
 
-	jumpMapAllocs    map[hook.Hook]*jumpMapAlloc
-	policyTcAllowFDs [2]bpf.ProgFD
-	policyTcDenyFDs  [2]bpf.ProgFD
+	jumpMapAllocs          map[hook.Hook]*jumpMapAlloc
+	netkitJumpMapAllocs    map[hook.Hook]*jumpMapAlloc
+	policyTcAllowFDs       [2]bpf.ProgFD
+	policyTcDenyFDs        [2]bpf.ProgFD
+	policyNetkitAllowFDs   [2]bpf.ProgFD
+	policyNetkitDenyFDs    [2]bpf.ProgFD
+	netkitPoliciesLoaded   sync.Once
 
 	ruleRenderer bpfAllowChainRenderer
 
@@ -508,6 +512,10 @@ func NewBPFEndpointManager(
 			hook.Ingress: newJumpMapAlloc("ingress", jump.TCMaxEntryPoints),
 			hook.Egress:  newJumpMapAlloc("egress", jump.TCMaxEntryPoints),
 			hook.XDP:     newJumpMapAlloc("xdp", jump.XDPMaxEntryPoints),
+		},
+		netkitJumpMapAllocs: map[hook.Hook]*jumpMapAlloc{
+			hook.Ingress: newJumpMapAlloc("netkit-ingress", jump.TCMaxEntryPoints),
+			hook.Egress:  newJumpMapAlloc("netkit-egress", jump.TCMaxEntryPoints),
 		},
 		ruleRenderer:     iptablesRuleRenderer,
 		onStillAlive:     livenessCallback,
@@ -751,7 +759,11 @@ func (m *bpfEndpointManager) repinJumpMaps() error {
 	for _, mp := range m.commonMaps.JumpMaps {
 		mps = append(mps, mp)
 	}
+	for _, mp := range m.commonMaps.NetkitJumpMaps {
+		mps = append(mps, mp)
+	}
 	mps = append(mps, m.commonMaps.ProgramsMaps...)
+	mps = append(mps, m.commonMaps.NetkitProgramsMaps...)
 	for _, mp := range mps {
 		pin := path.Join(tmp, mp.GetName())
 		if err := libbpf.ObjPin(int(mp.MapFD()), pin); err != nil {
@@ -1644,59 +1656,113 @@ func (m *bpfEndpointManager) syncIfaceProperties() error {
 	return nil
 }
 
-// loadDefaultPolicies loads the default allow and deny policy programs for the given hook
-// and not policy direction.
+// loadDefaultPolicies loads the default allow and deny policy programs for the given hook.
 func (m *bpfEndpointManager) loadDefaultPolicies(hk hook.Hook) error {
+	allowFD, denyFD, err := m.loadDefaultPolicyPrograms(hk, string(m.bpfAttachType), nil)
+	if err != nil {
+		return err
+	}
+	m.policyTcAllowFDs[hk] = allowFD
+	m.policyTcDenyFDs[hk] = denyFD
+	return nil
+}
+
+// ensureNetkitDefaultPolicies lazily loads netkit default policy programs on first use.
+func (m *bpfEndpointManager) ensureNetkitDefaultPolicies() error {
+	var loadErr error
+	m.netkitPoliciesLoaded.Do(func() {
+		for _, hk := range []hook.Hook{hook.Ingress, hook.Egress} {
+			var pinOverrides map[string]string
+			if hk == hook.Ingress {
+				pinOverrides = hook.NetkitPinOverridesIngress()
+			} else {
+				pinOverrides = hook.NetkitPinOverridesEgress()
+			}
+			allowFD, denyFD, err := m.loadDefaultPolicyPrograms(hk, tc.AttachOptionNetkit, pinOverrides)
+			if err != nil {
+				loadErr = fmt.Errorf("loading netkit default policies for %s: %w", hk, err)
+				return
+			}
+			m.policyNetkitAllowFDs[hk] = allowFD
+			m.policyNetkitDenyFDs[hk] = denyFD
+		}
+	})
+	return loadErr
+}
+
+// loadDefaultPolicyPrograms loads the default allow/deny policy programs for the
+// given hook and attach type. mapPinOverrides allows redirecting prog_array maps
+// to alternate pin paths (used for netkit).
+func (m *bpfEndpointManager) loadDefaultPolicyPrograms(
+	hk hook.Hook,
+	progAttachType string,
+	mapPinOverrides map[string]string,
+) (allowFD, denyFD bpf.ProgFD, err error) {
 	file := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("policy_default_%s.o", hk))
 	obj, err := libbpf.OpenObject(file)
 	if err != nil {
-		return fmt.Errorf("file %s: %w", file, err)
+		return 0, 0, fmt.Errorf("file %s: %w", file, err)
 	}
 
-	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
-		mapName := m.Name()
+	for mp, err := obj.FirstMap(); mp != nil && err == nil; mp, err = mp.NextMap() {
+		mapName := mp.Name()
 		if strings.HasPrefix(mapName, ".rodata") {
 			continue
 		}
 		if size := maps.Size(mapName); size != 0 {
-			if err := m.SetSize(size); err != nil {
-				return fmt.Errorf("error resizing map %s: %w", mapName, err)
+			if err := mp.SetSize(size); err != nil {
+				return 0, 0, fmt.Errorf("error resizing map %s: %w", mapName, err)
 			}
 		}
-		if err := m.SetPinPath(path.Join(bpfdefs.GlobalPinDir, mapName)); err != nil {
-			return fmt.Errorf("error pinning map %s: %w", mapName, err)
+		pinPath := path.Join(bpfdefs.GlobalPinDir, mapName)
+		if override, ok := mapPinOverrides[mapName]; ok {
+			pinPath = override
+		}
+		if err := mp.SetPinPath(pinPath); err != nil {
+			return 0, 0, fmt.Errorf("error pinning map %s: %w", mapName, err)
 		}
 	}
 
-	if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+	switch progAttachType {
+	case string(apiv3.BPFAttachOptionTCX):
 		for p, err := obj.FirstProgram(); p != nil && err == nil; p, err = p.NextProgram() {
 			attachType := libbpf.AttachTypeTcxEgress
 			if hk == hook.Ingress {
 				attachType = libbpf.AttachTypeTcxIngress
 			}
 			if err := obj.SetAttachType(p.Name(), attachType); err != nil {
-				return fmt.Errorf("error setting attach type for program %s: %w", p.Name(), err)
+				return 0, 0, fmt.Errorf("error setting attach type for program %s: %w", p.Name(), err)
+			}
+		}
+	case tc.AttachOptionNetkit:
+		for p, err := obj.FirstProgram(); p != nil && err == nil; p, err = p.NextProgram() {
+			attachType := libbpf.AttachTypeNetkitPrimary
+			if hk == hook.Ingress {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+			if err := obj.SetAttachType(p.Name(), attachType); err != nil {
+				return 0, 0, fmt.Errorf("error setting netkit attach type for program %s: %w", p.Name(), err)
 			}
 		}
 	}
 
 	if err := obj.Load(); err != nil {
-		return fmt.Errorf("default policies: %w", err)
+		return 0, 0, fmt.Errorf("default policies (%s): %w", progAttachType, err)
 	}
 
 	fd, err := obj.ProgramFD("calico_tc_deny")
 	if err != nil {
-		return fmt.Errorf("failed to load default deny policy program: %w", err)
+		return 0, 0, fmt.Errorf("failed to load default deny policy program: %w", err)
 	}
-	m.policyTcDenyFDs[hk] = bpf.ProgFD(fd)
+	denyFD = bpf.ProgFD(fd)
 
 	fd, err = obj.ProgramFD("calico_tc_allow")
 	if err != nil {
-		return fmt.Errorf("failed to load default allow policy program: %w", err)
+		return 0, 0, fmt.Errorf("failed to load default allow policy program: %w", err)
 	}
-	m.policyTcAllowFDs[hk] = bpf.ProgFD(fd)
+	allowFD = bpf.ProgFD(fd)
 
-	return nil
+	return allowFD, denyFD, nil
 }
 
 func (m *bpfEndpointManager) CompleteDeferredWork() error {
@@ -2197,11 +2263,15 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 	}
 }
 
-func (m *bpfEndpointManager) allocJumpIndicesForWEP(ifaceName string, idx *bpfInterfaceJumpIndices) error {
+func (m *bpfEndpointManager) allocJumpIndicesForWEP(ifaceName string, isNetkit bool, idx *bpfInterfaceJumpIndices) error {
+	allocs := m.jumpMapAllocs
+	if isNetkit {
+		allocs = m.netkitJumpMapAllocs
+	}
 	for _, h := range []hook.Hook{hook.Ingress, hook.Egress} {
 		if idx.policyIdx[h] == -1 {
 			var err error
-			idx.policyIdx[h], err = m.jumpMapAllocs[h].Get(ifaceName)
+			idx.policyIdx[h], err = allocs[h].Get(ifaceName)
 			if err != nil {
 				return err
 			}
@@ -2238,9 +2308,11 @@ func (m *bpfEndpointManager) allocJumpIndicesForDataIface(ifaceName string, xdpM
 func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInterfaceState) error {
 	var err error
 
+	isNetkit := string(ap.AttachType) == tc.AttachOptionNetkit
+
 	// Allocate indices for IPv4
 	if m.v4 != nil {
-		err = m.allocJumpIndicesForWEP(ap.IfaceName(), &state.v4)
+		err = m.allocJumpIndicesForWEP(ap.IfaceName(), isNetkit, &state.v4)
 		if err != nil {
 			return err
 		}
@@ -2248,16 +2320,20 @@ func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInt
 
 	// Allocate indices for IPv6
 	if m.v6 != nil {
-		err = m.allocJumpIndicesForWEP(ap.IfaceName(), &state.v6)
+		err = m.allocJumpIndicesForWEP(ap.IfaceName(), isNetkit, &state.v6)
 		if err != nil {
 			return err
 		}
 	}
 
+	filterAllocs := m.jumpMapAllocs
+	if isNetkit {
+		filterAllocs = m.netkitJumpMapAllocs
+	}
 	if ap.LogLevel == "debug" {
 		for _, h := range []hook.Hook{hook.Ingress, hook.Egress} {
 			if state.filterIdx[h] == -1 {
-				state.filterIdx[h], err = m.jumpMapAllocs[h].Get(ap.IfaceName())
+				state.filterIdx[h], err = filterAllocs[h].Get(ap.IfaceName())
 				if err != nil {
 					return err
 				}
@@ -2268,7 +2344,7 @@ func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInt
 			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook]); err != nil {
 				logrus.WithError(err).Warn("Filter program may leak.")
 			}
-			if err := m.jumpMapAllocs[attachHook].Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
+			if err := filterAllocs[attachHook].Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
 				logrus.WithError(err).Errorf("Filter hook %s", attachHook)
 			}
 			state.filterIdx[attachHook] = -1
@@ -2418,6 +2494,12 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	// manage this way — other netkit devices (host/data interfaces) are not ours.
 	if ifaceType == IfaceTypeNetkit && m.isWorkloadIface(ifaceName) && tc.IsNetkitSupported() {
 		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
+		// Netkit programs have a different expected_attach_type and cannot
+		// share prog_array maps with TC/TCX programs. Use separate maps.
+		// Note: the AP is copied for both directions in applyPolicyToWeps,
+		// so we set overrides for both ingress and egress here. The ProgramsMap
+		// is set per-direction in wepApplyPolicyToDirection.
+		ap.MapPinOverrides = hook.NetkitPinOverridesBoth()
 	}
 	if wep != nil && wep.QosControls != nil {
 		// QoSControls are present, update state
@@ -3174,9 +3256,10 @@ func (d *bpfEndpointManagerDataplane) configureTCAttachPoint(policyDirection Pol
 		}
 	}
 
-	ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[hook.Ingress]
-	if ap.Hook == hook.Egress {
-		ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[hook.Egress]
+	if string(ap.AttachType) == tc.AttachOptionNetkit {
+		ap.ProgramsMap = d.mgr.commonMaps.NetkitProgramsMaps[ap.Hook]
+	} else {
+		ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[ap.Hook]
 	}
 
 	if d.mgr.FlowLogsEnabled() {
@@ -3866,14 +3949,24 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 		}
 
 		jmpMap := m.commonMaps.JumpMaps[aptc.Hook]
+		allowFDs := m.policyTcAllowFDs
+		denyFDs := m.policyTcDenyFDs
+		if string(aptc.AttachType) == tc.AttachOptionNetkit {
+			jmpMap = m.commonMaps.NetkitJumpMaps[aptc.Hook]
+			if err := m.ensureNetkitDefaultPolicies(); err != nil {
+				return err
+			}
+			allowFDs = m.policyNetkitAllowFDs
+			denyFDs = m.policyNetkitDenyFDs
+		}
 		// Load default policy before the real policy is created and loaded.
 		switch at.DefaultPolicy() {
 		case hook.DefPolicyAllow:
 			err = maps.UpdateMapEntry(jmpMap.MapFD(),
-				jump.Key(policyIdx), jump.Value(m.policyTcAllowFDs[aptc.Hook].FD()))
+				jump.Key(policyIdx), jump.Value(allowFDs[aptc.Hook].FD()))
 		case hook.DefPolicyDeny:
 			err = maps.UpdateMapEntry(jmpMap.MapFD(),
-				jump.Key(policyIdx), jump.Value(m.policyTcDenyFDs[aptc.Hook].FD()))
+				jump.Key(policyIdx), jump.Value(denyFDs[aptc.Hook].FD()))
 		}
 
 		if err != nil {
@@ -4053,7 +4146,12 @@ func (m *bpfEndpointManager) loadTCLogFilter(ap *tc.AttachPoint) (fileDescriptor
 	}
 
 	attachType := uint32(0)
-	if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+	if string(ap.AttachType) == tc.AttachOptionNetkit {
+		attachType = libbpf.AttachTypeNetkitPrimary
+		if ap.Hook == hook.Ingress {
+			attachType = libbpf.AttachTypeNetkitPeer
+		}
+	} else if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
 		attachType = libbpf.AttachTypeTcxIngress
 		if ap.Hook == hook.Egress {
 			attachType = libbpf.AttachTypeTcxEgress
@@ -4076,7 +4174,11 @@ func (m *bpfEndpointManager) updateLogFilter(ap attachPoint) error {
 			return err
 		}
 		defer fd.Close()
-		if err := m.commonMaps.JumpMaps[t.Hook].Update(jump.Key(idx), jump.Value(fd.FD())); err != nil {
+		jmpMap := m.commonMaps.JumpMaps[t.Hook]
+		if string(t.AttachType) == tc.AttachOptionNetkit {
+			jmpMap = m.commonMaps.NetkitJumpMaps[t.Hook]
+		}
+		if err := jmpMap.Update(jump.Key(idx), jump.Value(fd.FD())); err != nil {
 			return fmt.Errorf("failed to update %s policy jump map [%d]=%d: %w", ap.HookName(), idx, fd.FD(), err)
 		}
 
@@ -4203,7 +4305,13 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 	if apTc, ok := ap.(*tc.AttachPoint); ok {
 		staticProgsMap = apTc.ProgramsMap
 		polProgsMap = m.commonMaps.JumpMaps[apTc.Hook]
-		if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+		if string(apTc.AttachType) == tc.AttachOptionNetkit {
+			polProgsMap = m.commonMaps.NetkitJumpMaps[apTc.Hook]
+			attachType = libbpf.AttachTypeNetkitPrimary
+			if apTc.Hook == hook.Ingress {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+		} else if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
 			attachType = libbpf.AttachTypeTcxIngress
 			if apTc.Hook == hook.Egress {
 				attachType = libbpf.AttachTypeTcxEgress

--- a/felix/fv/infrastructure/modes.go
+++ b/felix/fv/infrastructure/modes.go
@@ -20,3 +20,9 @@ import "os"
 func NFTMode() bool {
 	return os.Getenv("FELIX_FV_NFTABLES") == "Enabled"
 }
+
+// NetkitMode returns true if FV tests are configured to use netkit devices
+// instead of veth pairs for workload endpoints.
+func NetkitMode() bool {
+	return os.Getenv("FELIX_FV_NETKIT") == "Enabled"
+}

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -47,7 +48,7 @@ const usage = `test-workload, test workload for Felix FV testing.
 If <interface-name> is "", the workload will start in the current namespace.
 
 Usage:
-  test-workload [--protocol=<protocol>] [--namespace-path=<path>] [--sidecar-iptables] [--mtu=<mtu>] [--listen-any-ip] <interface-name> <ip-address> <ports>
+  test-workload [--protocol=<protocol>] [--namespace-path=<path>] [--sidecar-iptables] [--mtu=<mtu>] [--listen-any-ip] [--netkit] <interface-name> <ip-address> <ports>
 `
 
 func main() {
@@ -81,6 +82,10 @@ func main() {
 	listenAnyIP := false
 	if arg, ok := arguments["--listen-any-ip"]; ok && arg.(bool) {
 		listenAnyIP = true
+	}
+	useNetkit := false
+	if arg, ok := arguments["--netkit"]; ok && arg.(bool) {
+		useNetkit = true
 	}
 
 	ports := strings.Split(portsStr, ",")
@@ -118,11 +123,6 @@ func main() {
 		}
 		log.WithField("namespace", namespace.Path()).Debug("Created namespace")
 
-		conf := types.NetConf{
-			MTU:       mtu,
-			NumQueues: 1,
-		}
-		dp := linux.NewLinuxDataplane(conf, log.WithField("ns", namespace.Path()))
 		hostVethName := interfaceName
 		var addrs []*cniv1.IPConfig
 		if ipv4Addr != "" {
@@ -153,15 +153,25 @@ func main() {
 		panicIfError(err)
 
 		defer hostNlHandle.Close()
-		_, err = dp.DoWorkloadNetnsSetUp(
-			hostNlHandle,
-			namespace.Path(),
-			addrs,
-			"eth0",
-			hostVethName,
-			routes,
-			nil,
-		)
+
+		if useNetkit {
+			err = doNetkitSetUp(hostNlHandle, namespace, addrs, "eth0", hostVethName, routes, mtu)
+		} else {
+			conf := types.NetConf{
+				MTU:       mtu,
+				NumQueues: 1,
+			}
+			dp := linux.NewLinuxDataplane(conf, log.WithField("ns", namespace.Path()))
+			_, err = dp.DoWorkloadNetnsSetUp(
+				hostNlHandle,
+				namespace.Path(),
+				addrs,
+				"eth0",
+				hostVethName,
+				routes,
+				nil,
+			)
+		}
 		panicIfError(err)
 	} else {
 		namespace, err = ns.GetCurrentNS()
@@ -434,6 +444,191 @@ func loopRespondingToPackets(logCxt *log.Entry, p net.PacketConn) {
 			logCxt.WithError(err).WithField("remoteAddr", addr).Info("Responded")
 		}
 	}
+}
+
+// doNetkitSetUp creates a netkit L2 pair instead of a veth pair for the workload.
+// The primary (host-side) end stays in the host namespace; the peer is moved into
+// the workload namespace. IP addresses, routes and sysctls are configured to match
+// what DoWorkloadNetnsSetUp does for veth pairs.
+func doNetkitSetUp(
+	hostNlHandle *netlink.Handle,
+	workloadNS ns.NetNS,
+	ipAddrs []*cniv1.IPConfig,
+	contIfName string,
+	hostIfName string,
+	routes []*net.IPNet,
+	mtu int,
+) error {
+	// Clean up if host-side interface already exists.
+	if oldLink, err := hostNlHandle.LinkByName(hostIfName); err == nil {
+		if err = hostNlHandle.LinkDel(oldLink); err != nil {
+			return fmt.Errorf("failed to delete old host interface %v: %v", hostIfName, err)
+		}
+		log.Infof("Cleaned up old host interface: %v", hostIfName)
+	}
+
+	// Determine IP versions present.
+	var hasIPv4, hasIPv6 bool
+	for _, addr := range ipAddrs {
+		if addr.Address.IP.To4() != nil {
+			hasIPv4 = true
+			addr.Address.Mask = net.CIDRMask(32, 32)
+		} else if addr.Address.IP.To16() != nil {
+			hasIPv6 = true
+			addr.Address.Mask = net.CIDRMask(128, 128)
+		}
+	}
+
+	// Create netkit in host namespace, with peer placed in workload namespace.
+	la := netlink.NewLinkAttrs()
+	la.Name = hostIfName
+	la.MTU = mtu
+	nk := &netlink.Netkit{
+		LinkAttrs: la,
+		Mode:      netlink.NETKIT_MODE_L2,
+	}
+	nk.SetPeerAttrs(&netlink.LinkAttrs{
+		Name:      contIfName,
+		Namespace: netlink.NsFd(int(workloadNS.Fd())),
+	})
+	if err := netlink.LinkAdd(nk); err != nil {
+		return fmt.Errorf("failed to add netkit pair (%s, %s): %w", hostIfName, contIfName, err)
+	}
+	log.Infof("Created netkit pair: host=%s container=%s (in workload NS)", hostIfName, contIfName)
+
+	// Configure host-side interface: MAC, proxy_arp, bring up.
+	hostLink, err := hostNlHandle.LinkByName(hostIfName)
+	if err != nil {
+		return fmt.Errorf("failed to find host-side netkit %s: %w", hostIfName, err)
+	}
+	hostMAC, _ := net.ParseMAC("ee:ee:ee:ee:ee:ee")
+	if err := hostNlHandle.LinkSetHardwareAddr(hostLink, hostMAC); err != nil {
+		log.Warnf("Failed to set MAC on %s: %v (using kernel-assigned MAC)", hostIfName, err)
+	}
+
+	// Host-side sysctls (proxy_arp, forwarding, etc.)
+	if hasIPv4 {
+		writeProcSysOrLog("/proc/sys/net/ipv4/conf/%s/route_localnet", hostIfName, "1")
+		writeProcSysOrLog("/proc/sys/net/ipv4/neigh/%s/proxy_delay", hostIfName, "0")
+		writeProcSysOrLog("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostIfName, "1")
+		writeProcSysOrLog("/proc/sys/net/ipv4/conf/%s/forwarding", hostIfName, "1")
+	}
+	if hasIPv6 {
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/accept_dad", hostIfName, "0")
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/disable_ipv6", hostIfName, "0")
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/proxy_ndp", hostIfName, "1")
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/forwarding", hostIfName, "1")
+	}
+
+	if err := hostNlHandle.LinkSetUp(hostLink); err != nil {
+		return fmt.Errorf("failed to set %s up: %w", hostIfName, err)
+	}
+
+	// Configure container-side interface inside the workload namespace.
+	err = workloadNS.Do(func(_ ns.NetNS) error {
+		contLink, err := netlink.LinkByName(contIfName)
+		if err != nil {
+			return fmt.Errorf("failed to find container netkit %s: %w", contIfName, err)
+		}
+
+		if hasIPv6 {
+			// Disable DAD before bringing the interface up.
+			if err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/accept_dad", contIfName), "0"); err != nil {
+				return err
+			}
+		}
+
+		if err := netlink.LinkSetUp(contLink); err != nil {
+			return fmt.Errorf("failed to set %s up: %w", contIfName, err)
+		}
+
+		// Add IP addresses.
+		for _, addr := range ipAddrs {
+			if err := netlink.AddrAdd(contLink, &netlink.Addr{IPNet: &addr.Address}); err != nil {
+				return fmt.Errorf("failed to add IP %v to %s: %w", addr.Address, contIfName, err)
+			}
+		}
+
+		// Add IPv4 routes.
+		if hasIPv4 {
+			gw := net.IPv4(169, 254, 1, 1)
+			gwNet := &net.IPNet{IP: gw, Mask: net.CIDRMask(32, 32)}
+			if err := netlink.RouteAdd(&netlink.Route{
+				LinkIndex: contLink.Attrs().Index,
+				Scope:     netlink.SCOPE_LINK,
+				Dst:       gwNet,
+			}); err != nil {
+				return fmt.Errorf("failed to add gateway route: %w", err)
+			}
+			for _, r := range routes {
+				if r.IP.To4() == nil {
+					continue
+				}
+				if err := netlink.RouteAdd(&netlink.Route{
+					LinkIndex: contLink.Attrs().Index,
+					Dst:       r,
+					Gw:        gw,
+				}); err != nil {
+					return fmt.Errorf("failed to add IPv4 route %v: %w", r, err)
+				}
+			}
+		}
+
+		// Add IPv6 routes.
+		if hasIPv6 {
+			// Enable IPv6 in the namespace.
+			_ = writeProcSys("/proc/sys/net/ipv6/conf/all/disable_ipv6", "0")
+			_ = writeProcSys("/proc/sys/net/ipv6/conf/default/disable_ipv6", "0")
+			_ = writeProcSys("/proc/sys/net/ipv6/conf/lo/disable_ipv6", "0")
+
+			// Get the host-side link-local address for use as IPv6 gateway.
+			var hostIPv6 net.IP
+			for i := range 10 {
+				if i > 0 {
+					time.Sleep(50 * time.Millisecond)
+				}
+				addrs, err := hostNlHandle.AddrList(hostLink, netlink.FAMILY_V6)
+				if err == nil && len(addrs) > 0 {
+					hostIPv6 = addrs[0].IP
+					break
+				}
+			}
+			if hostIPv6 == nil {
+				return fmt.Errorf("failed to get IPv6 link-local address for %s", hostIfName)
+			}
+			for _, r := range routes {
+				if r.IP.To4() != nil {
+					continue
+				}
+				if err := netlink.RouteAdd(&netlink.Route{
+					LinkIndex: contLink.Attrs().Index,
+					Dst:       r,
+					Gw:        hostIPv6,
+				}); err != nil {
+					return fmt.Errorf("failed to add IPv6 route %v: %w", r, err)
+				}
+			}
+		}
+
+		// Container-side sysctls (rp_filter, etc.)
+		if hasIPv4 {
+			_ = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", contIfName), "1")
+		}
+
+		return nil
+	})
+	return err
+}
+
+func writeProcSysOrLog(pathFmt, ifName, value string) {
+	path := fmt.Sprintf(pathFmt, ifName)
+	if err := writeProcSys(path, value); err != nil {
+		log.Warnf("Failed to write %s=%s: %v", path, value, err)
+	}
+}
+
+func writeProcSys(path, value string) error {
+	return os.WriteFile(path, []byte(value), 0644)
 }
 
 func panicIfError(err error) {

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -263,8 +263,13 @@ func (w *Workload) Start(cleanupProvider CleanupProvider) error {
 	if w.IP6 != "" {
 		wIP = wIP + "," + w.IP6
 	}
-	command := fmt.Sprintf("echo $$; exec test-workload %v '%v' '%v' '%v'",
+	var netkitArg string
+	if infrastructure.NetkitMode() {
+		netkitArg = "--netkit"
+	}
+	command := fmt.Sprintf("echo $$; exec test-workload %v %v '%v' '%v' '%v'",
 		protoArg,
+		netkitArg,
 		w.InterfaceName,
 		wIP,
 		w.Ports,


### PR DESCRIPTION
## Summary

Initial implementation of native netkit BPF attachment in Felix. When Felix detects a workload endpoint using a netkit device (instead of veth), it attaches BPF programs via the netkit attach API rather than TC/TCX. This is the foundation for supporting netkit as an alternative to veth for workload networking.

- **Netkit detection and attachment**: Felix auto-detects netkit workload interfaces and uses `BPF_NETKIT_PRIMARY`/`BPF_NETKIT_PEER` attachment instead of TC/TCX
- **Separate prog_array maps**: Netkit programs have a different `expected_attach_type` and cannot share `prog_array` maps with TC/TCX programs. New maps (`cali_p_nk_ing2`, `cali_p_nk_egr2`, `cali_j_nk_ing2`, `cali_j_nk_egr2`) with pin path overrides redirect the same BPF object files to netkit-specific maps
- **host_ifindex in globals**: `BPF_NETKIT_PEER` programs see the peer's ifindex in `skb->ifindex`; added `host_ifindex` to globals for correct map lookups
- **No bpf_redirect_peer for netkit**: Netkit programs run in xmit context where `bpf_redirect_peer` silently drops; uses plain `bpf_redirect` via FIB instead
- **FV test infrastructure**: `--netkit` flag for test-workload, `FELIX_FV_NETKIT=Enabled` env var, `fv-bpf-netkit` Makefile target
- **CI**: Full BPF FV run with netkit on Ubuntu 25.10 (replaces UT-only 25.10 check)

## Test plan

- [x] `make -C felix fv-bpf-netkit` with connectivity test (ipv4 tcp, no tunnel, no dsr) passes
- [ ] Full BPF FV suite with netkit on Ubuntu 25.10 CI runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)