### PR TITLE
[BPF] Fix node-unreachable on Felix restart with no Node

### DIFF
--- a/.kagent-poc-test
+++ b/.kagent-poc-test
@@ -1,0 +1,1 @@
+kagent CI triage PoC marker - 2026-05-27T17:06:09Z


### PR DESCRIPTION
## Summary

Fixes #12642 — in BPF mode, after `kubectl delete node <self>` followed by a Felix restart, the node loses all network connectivity (no SSH, no etcd/apiserver) and cannot recover on its own.

Supersedes #12656 (cleanup-gate band-aid) and #12688 (same approach as this PR but without an FV).

## Mechanism (verified via FV, see "Test" section)

1. New Felix runs `repinJumpMaps()` to move the previous Felix's jump maps under `old_jumps/<tmp>/` and creates fresh empty maps at the original pin paths. The previous Felix's preambles (still attached to host interfaces) reference the OLD maps' kernel IDs.
2. Without a Node, `wepApplyPolicyToDirection` / `attachDataIfaceProgram` short-circuit with `"unknown host IP"`; new preambles are never installed.
3. `doApplyPolicy*` clears the per-family `"unknown host IP"` error at the bottom (the dual-stack "don't fail v4 if only v6 is enabled" trick swallows it), so `dirtyIfaceNames` empties.
4. With `dirtyIfaceNames.Len() == 0`, the cleanup gate fires `os.RemoveAll(old_jumps)`. The OLD maps lose their pin; program references from BPF programs alone do not keep `prog_array` entries alive, so the kernel reclaims the slots.
5. The OLD preambles are still attached, but every `bpf_tail_call` into the now-empty maps fails. Every packet through `eth0` is dropped.

## Approach

The host IP is meaningfully consumed by very few BPF features:

- VXLAN return-path encap source (`tc.c:975, 1087, 1200` — `STATE->ip_src = HOST_IP`).
- An IPv4 RPF strict-mode link-local check (`rpf.h:134`) — naturally evaluates false when `HOST_IP=0`.
- A debug log in `vxlan_attempt_decap`. The decap decision itself uses a route-table lookup, not `HOST_IP`.

Everything else — policy, conntrack, NAT, ICMP, kube-proxy replacement, non-VXLAN forwarding — works fine without `HOST_IP`.

**Stop using "no host IP" as a hard gate.** Programs now attach as normal with `HOST_IP=0` as a sentinel. The Go-side already handled `nil` host IP in the globals plumbing (`copy(dst, (nil net.IP).To4())` is a no-op, so `globalData.HostIPv*` stays at zero); the gates were the only thing short-circuiting before that.

The three VXLAN encap-source sites in `tc.c` now check `ip_void(HOST_IP)` and, if true, drop the packet with a new `CALI_REASON_NO_HOST_IP` / `DroppedNoHostIP` counter (slot 26 in the counters map; `RESERVED1` is preserved for downstream use).

### Deliberate non-reaction to `HostMetadataRemove`

When the local Node is deleted *without* a Felix restart, kubelet will shortly terminate the calico-node pod via SIGTERM. Doing a full mark-all-ifaces-dirty + re-attach + service-rebuild pass in that window risks Felix being killed mid-apply, leaving the BPF dataplane in an inconsistent state (preambles tail-calling into freed jump-map slots) that the still-pinned BPF programs cannot recover from after Felix is gone.

Validated on a real cluster: adding a `HostMetadataRemove` handler that triggered the rebuild broke connectivity within ~4 seconds of `kubectl delete node`; without the handler, the pinned BPF programs continue running with their last-known `HOST_IP` cached in their globals and connectivity survives the pod teardown intact.

The Felix-restart-with-no-Node case (the original bug) is handled by the gate removal above — a fresh Felix attaches programs with `HOST_IP=0` from the start, no mid-flight rebuild involved.

Co-authored with Shaun Crampton (most of the C/Go fix is from #12688).

## Test

`felix/fv/bpf_node_delete_test.go` adds two scenarios:

- **Node delete only**: deletes the Calico Node and Consistently probes host SSH over 10s. The pinned BPF programs keep running, connectivity holds throughout regardless of Felix's reaction (or lack thereof) to the event.
- **Node delete + Felix restart + recovery**: deletes the Node, sends SIGHUP to Felix, and immediately starts a 15s Consistently — without waiting for the new PID. The probe loop spans Felix's exit, restart, startup, `repinJumpMaps`, and first apply pass. Re-adds the Node, watches for the `"Host IP changed"` log signal, and Consistently probes for another 10s through the recovery re-attach.

`felix/fv/bpf_dual_stack_test.go` repurposes the `"with IPv*N addresses only"` tests to validate the new behaviour and adds a new `"with IPv6 host IP removed from one node only"` test that codifies the cross-node NodePort breakage when a node lacks a family's host IP — exercises the encap-source drop site via an external client, asserts both the connectivity drop and the `DroppedNoHostIP` counter increment.

**Empirically validated**:

| Run | Test 1 | Test 2 |
|---|---|---|
| Master (no fix) + test | PASS (21s) | **FAIL @ 4.568s** — BPF trace shows `tc_preamble failed to call main 37`, exactly the bug mechanism |
| This PR (with `HostMetadataRemove` handler) — first iteration | PASS (FV) | PASS (FV) — but broke real cluster |
| This PR (final, handler dropped) | PASS (21s) | PASS (36s) — 62 probes, 0 drops |

**Cluster validation** (banzai GCP kubeadm, kernel 6.8, BPF mode, 4 nodes):

Used `kubectl delete node <test-node>` to drive the calc graph `HostMetadataRemove` event. With an earlier iteration of this PR that included a `HostMetadataRemove` handler in `bpf_ep_mgr.go`, all traffic to the affected node dropped within ~4 seconds of the delete — the rebuild pass races kubelet's SIGTERM and leaves the BPF state inconsistent. With the handler removed, `kubectl delete node` + pod GC consistently leaves connectivity intact: pinned BPF programs continue running with cached `HOST_IP`, and 120 consecutive 1-Hz probes from a peer node passed without a single drop. Cluster behaviour now matches master in this respect; the FV bug fix is preserved via the gate removal.

**Release note:**
```release-note
Fixes a bug in the eBPF dataplane in which deleting and restoring the local Node resource and restarting Felix could leave the node unable to handle network traffic.
```

## Behavior change: per-family attach is now driven by config, not by host IP

Pre-PR, BPF programs for a given IP family (v4/v6) were skipped at attach time when that family's host IP was nil — the `"unknown host IP"` early-returns in `wepApplyPolicyToDirection` / `attachDataIfaceProgram` short-circuited the attach. This PR removes those gates (they're the root of the bug) and lets programs attach with `HOST_IP=0`.

Practical consequence: on a Felix configured for dual-stack (`BPFIpv6Enabled=true`) but running on a host that only has an IPv4 address, v6 BPF programs are now attached too (with `HOST_IPv6=0`). Pre-PR they were not.

This is the right behavior. Felix can't distinguish pure-IPv6, dual-stack, and "v6-enabled-but-host-has-no-v6" configurations from each other — they all look identical to the dataplane. The "v6 enabled" config flag is the operator's signal that v6 attach is wanted; the previous per-host-IP gate was second-guessing that. For the `BPFIpv6Enabled=false` case (`m.v6 == nil` from construction), no v6 programs are attached, same as before.

Cost: a few extra BPF programs attached on misconfigured hosts (v6 enabled in Felix but no v6 address present). Negligible at runtime — they only execute on v6 packets, which never arrive on such hosts.